### PR TITLE
feat: update UI with all existing functionality in DnD Kit Kanban board

### DIFF
--- a/frontend/ui/src/components/kanban-board/board/board-column.tsx
+++ b/frontend/ui/src/components/kanban-board/board/board-column.tsx
@@ -2,7 +2,17 @@ import {
   draggable,
   dropTargetForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-
+import {
+  Ellipsis,
+  Plus,
+  Trash2,
+  Edit3,
+  GripVertical,
+  Check,
+  X,
+  Loader2,
+  Sparkles,
+} from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ColorPicker, { ColorSelectType } from "@components/color-picker";
 import invariant from "tiny-invariant";
@@ -31,13 +41,13 @@ import {
   DropdownMenu,
   TextArea,
 } from "@radixui";
-import {Icon, Heading} from "@incmix/ui"
 import { isSafari } from "@utils/browser";
 import { isShallowEqual } from "@incmix/utils/objects";
 import { blockBoardPanningAttr } from "../data-attributes";
 import { TaskCard, TaskCardShadow } from "./task-card";
 import { useAIFeaturesStore } from "@incmix/store";
 import { TaskDataSchema } from "@incmix/utils/schema";
+import {Heading} from "@incmix/ui"
 
 // Define types for drag and drop operations
 type DragData = {
@@ -82,7 +92,6 @@ const idle = { type: "idle" } satisfies TColumnState;
 
 interface BoardColumnProps {
   column: KanbanColumn;
-  priorityLabels?: any[]; // Array of priority labels from useKanban hook
   onCreateTask: (
     columnId: string,
     taskData: Partial<TaskDataSchema>,
@@ -109,7 +118,6 @@ const QuickTaskForm = memo(function QuickTaskForm({
   columnId,
   onCreateTask,
   onCancel,
-  priorityLabels,
 }: {
   columnId: string;
   onCreateTask: (
@@ -117,7 +125,6 @@ const QuickTaskForm = memo(function QuickTaskForm({
     taskData: Partial<TaskDataSchema>,
   ) => Promise<void>;
   onCancel: () => void;
-  priorityLabels?: any[]; // Array of priority labels
 }) {
   // Get AI features state
   const { useAI } = useAIFeaturesStore();
@@ -210,14 +217,10 @@ const QuickTaskForm = memo(function QuickTaskForm({
 
       setIsSubmitting(true);
       try {
-        // Get first priority label id or empty string if none available
-        const defaultPriority = priorityLabels && priorityLabels.length > 0 ? 
-          priorityLabels[0].id : "";
-            
         await onCreateTask(columnId, {
           name: taskName.trim(),
           description: description.trim(),
-          priorityId: defaultPriority, // Use first available priority from labels
+          priorityId: "medium", // Updated: priority → priorityId
           completed: false,
           labelsTags: [],
           attachments: [],
@@ -275,12 +278,12 @@ const QuickTaskForm = memo(function QuickTaskForm({
           >
             {streamingState.isStreaming ? (
               <>
-                <Icon name="Loader" className="w-4 h-4 mr-2 animate-spin" />
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                 Generating...
               </>
             ) : (
               <>
-                <Icon name="Sparkles" className="w-4 h-4 mr-2" />
+                <Sparkles className="w-4 h-4 mr-2" />
                 Generate Description
               </>
             )}
@@ -304,7 +307,7 @@ const QuickTaskForm = memo(function QuickTaskForm({
           <Box className="text-xs">
             {streamingState.isStreaming && (
               <Flex align="center" gap="1" className="text-blue-500">
-                <Icon name="Loader" className="animate-spin" />
+                <Loader2 size={12} className="animate-spin" />
                 <Text>Generating description...</Text>
               </Flex>
             )}
@@ -318,7 +321,7 @@ const QuickTaskForm = memo(function QuickTaskForm({
               description &&
               streamingState.connectionStatus === "completed" && (
                 <Flex align="center" gap="1" className="text-green-600">
-                  <Icon name="Check" />
+                  <Check size={12} />
                   <Text>AI description generated</Text>
                 </Flex>
               )}
@@ -358,27 +361,27 @@ const QuickTaskForm = memo(function QuickTaskForm({
   );
 });
 
-export const TaskList = memo(function TaskList({
+const CardList = memo(function CardList({
   column,
-  priorityLabels,
   onUpdateTask,
   onDeleteTask,
   onTaskOpen,
 }: {
   column: KanbanColumn;
-  priorityLabels?: any[]; // Array of priority labels
-  onUpdateTask: (taskId: string, updates: Partial<TaskDataSchema>) => Promise<void>;
+  onUpdateTask: (
+    taskId: string,
+    updates: Partial<TaskDataSchema>,
+  ) => Promise<void>;
   onDeleteTask: (taskId: string) => Promise<void>;
   onTaskOpen?: (taskId: string) => void;
 }) {
   return (
     <>
-      {column.tasks.map((task) => (
+      {column.tasks.map((card) => (
         <TaskCard
-          key={task.id}
-          card={task}
+          key={card.id}
+          card={card}
           statusId={column.id}
-          priorityLabels={priorityLabels}
           onUpdateTask={onUpdateTask}
           onDeleteTask={onDeleteTask}
           onTaskOpen={onTaskOpen}
@@ -390,7 +393,6 @@ export const TaskList = memo(function TaskList({
 
 export const BoardColumn = memo(function BoardColumn({
   column,
-  priorityLabels,
   onCreateTask,
   onUpdateTask,
   onDeleteTask,
@@ -728,7 +730,7 @@ export const BoardColumn = memo(function BoardColumn({
                       onClick={handleUpdateColumn}
                       disabled={isUpdating}
                     >
-                      <Icon name="Check" />
+                      <Check size={14} />
                       {isUpdating ? "Saving..." : "Save"}
                     </Button>
                     <Button
@@ -739,7 +741,7 @@ export const BoardColumn = memo(function BoardColumn({
                       onClick={handleCancelEdit}
                       disabled={isUpdating}
                     >
-                      <Icon name="X" />
+                      <X size={14} />
                       Cancel
                     </Button>
                   </Flex>
@@ -748,6 +750,11 @@ export const BoardColumn = memo(function BoardColumn({
             ) : (
               <Flex justify="between" align="center">
                 <Flex align="center" gap="2" className="flex-1 min-w-0">
+                  {/* <GripVertical size={16} className="text-gray-400 flex-shrink-0" /> */}
+                  {/* <div
+                    className="w-3 h-3 rounded-full flex-shrink-0"
+                    style={{ backgroundColor: column.color }}
+                  /> */}
                   <Heading
                     size="5"
                     as="h3"
@@ -780,17 +787,17 @@ export const BoardColumn = memo(function BoardColumn({
                       variant="ghost"
                       className="rounded hover:bg-gray-200 dark:hover:bg-gray-700 flex-shrink-0"
                     >
-                      <Icon name="EllipsisVertical" />
+                      <Ellipsis size={16} />
                     </IconButton>
                   </DropdownMenu.Trigger>
                   <DropdownMenu.Content>
                     <DropdownMenu.Item onClick={() => setIsEditingColumn(true)}>
-                      <Icon name="SquarePen" />
+                      <Edit3 size={14} />
                       Edit Column
                     </DropdownMenu.Item>
                     <DropdownMenu.Separator />
                     <DropdownMenu.Item onClick={handleDeleteColumn} color="red">
-                      <Icon name="Trash2" />
+                      <Trash2 size={14} />
                       Delete Column
                     </DropdownMenu.Item>
                   </DropdownMenu.Content>
@@ -823,9 +830,8 @@ export const BoardColumn = memo(function BoardColumn({
           {/* Tasks Container - No internal scrolling, grows naturally */}
           <div className="px-2" ref={scrollableRef}>
             <div className="space-y-1 py-2">
-              <TaskList
+              <CardList
                 column={column}
-                priorityLabels={priorityLabels}
                 onUpdateTask={onUpdateTask}
                 onDeleteTask={onDeleteTask}
                 onTaskOpen={onTaskOpen}
@@ -843,7 +849,6 @@ export const BoardColumn = memo(function BoardColumn({
             {isCreatingTask ? (
               <QuickTaskForm
                 columnId={column.id}
-                priorityLabels={priorityLabels}
                 onCreateTask={onCreateTask}
                 onCancel={() => setIsCreatingTask(false)}
               />
@@ -854,7 +859,7 @@ export const BoardColumn = memo(function BoardColumn({
                 className="grid place-items-center gap-2 w-10 h-10 mx-auto"
                 onClick={() => setIsCreatingTask(true)}
               >
-                <Icon name="Plus" />
+                <Plus size={20} />
                 <Text className="sr-only">Add a task</Text>
               </Button>
             )}

--- a/frontend/ui/src/components/kanban-board/board/board-column.tsx
+++ b/frontend/ui/src/components/kanban-board/board/board-column.tsx
@@ -40,7 +40,7 @@ import {
   Text,
   DropdownMenu,
   TextArea,
-} from "@radixui";
+} from "@base";
 import { isSafari } from "@utils/browser";
 import { isShallowEqual } from "@incmix/utils/objects";
 import { blockBoardPanningAttr } from "../data-attributes";

--- a/frontend/ui/src/components/kanban-board/dnd-example/BoardColumn.tsx
+++ b/frontend/ui/src/components/kanban-board/dnd-example/BoardColumn.tsx
@@ -1,12 +1,31 @@
 import { SortableContext, useSortable } from "@dnd-kit/sortable";
 import { useDndContext, type UniqueIdentifier } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
-import { useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TaskCard } from "./TaskCard";
 import { cva } from "class-variance-authority";
-import { Card, Button, ScrollArea, Icon } from "@incmix/ui";
+import {
+  Card,
+  Button,
+  ScrollArea,
+  Icon,
+  useStreamingResponse,
+  useStreamingDisplay,
+  Box,
+  TextField,
+  TextArea,
+  Flex,
+  Text,
+  Heading,
+  DropdownMenu,
+  IconButton,
+} from "@incmix/ui";
 import type { KanbanColumn } from "../types";
 import { TaskDataSchema } from "@incmix/utils/schema";
+import { nanoid } from "nanoid";
+import { useAIFeaturesStore } from "@incmix/store";
+import { ModalPresets } from "../shared/confirmation-modal";
+import ColorPicker, { ColorSelectType } from "@components/color-picker";
 
 export type ColumnType = "Column";
 
@@ -36,6 +55,274 @@ interface BoardColumnProps {
   onTaskOpen?: (taskId: string) => void;
 }
 
+const QuickTaskForm = memo(function QuickTaskForm({
+  columnId,
+  onCreateTask,
+  onCancel,
+  priorityLabels,
+}: {
+  columnId: string;
+  onCreateTask: (
+    columnId: string,
+    taskData: Partial<TaskDataSchema>,
+  ) => Promise<void>;
+  onCancel: () => void;
+  priorityLabels?: any[]; // Array of priority labels
+}) {
+  // Get AI features state
+  const { useAI } = useAIFeaturesStore();
+
+  // Task form state
+  const [taskName, setTaskName] = useState("");
+  const [description, setDescription] = useState("");
+  const [checklist, setChecklist] = useState<
+    Array<{ id: string; text: string; checked: boolean; order: number }>
+  >([]);
+  const [acceptanceCriteria, setAcceptanceCriteria] = useState<
+    Array<{ id: string; text: string; checked: boolean; order: number }>
+  >([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Generate unique ID helper
+  const generateUniqueId = useCallback(
+    (prefix?: string, length = 10): string => {
+      const randomId = nanoid(length);
+      return prefix ? `${prefix}-${randomId}` : randomId;
+    },
+    [],
+  );
+
+  // Fetch data from AI endpoint as event stream
+  const [streamingState, streamingActions] = useStreamingResponse<{
+    userStory: {
+      description: string;
+      acceptanceCriteria: string[];
+      checklist: string[];
+    };
+  }>({
+    endpoint: "/generate-user-story",
+    method: "POST",
+    body: { prompt: taskName, userTier: "free", templateId: 1 },
+  });
+
+  // Function to process streaming data and update form
+  const setFormDataFromStream = useCallback(
+    (data?: {
+      description: string;
+      acceptanceCriteria: string[];
+      checklist: string[];
+    }) => {
+      if (data) {
+        // Set description
+        setDescription(data.description || "");
+
+        // Format checklist items with id, checked status and order
+        const formattedChecklist = (data.checklist || []).map(
+          (item, index) => ({
+            id: generateUniqueId("cl"),
+            text: item,
+            checked: false,
+            order: index,
+          }),
+        );
+        setChecklist(formattedChecklist);
+
+        // Format acceptance criteria items with id, checked status and order
+        const formattedAcceptanceCriteria = (data.acceptanceCriteria || []).map(
+          (item, index) => ({
+            id: generateUniqueId("ac"),
+            text: item,
+            checked: false,
+            order: index,
+          }),
+        );
+        setAcceptanceCriteria(formattedAcceptanceCriteria);
+      }
+    },
+    [generateUniqueId],
+  );
+
+  // Connect streaming data to form updates
+  useStreamingDisplay({
+    streamingData: streamingState.data,
+    isStreaming: streamingState.isStreaming,
+    connectionStatus: streamingState.connectionStatus,
+    onDataUpdate: (data) => {
+      setFormDataFromStream(data.userStory);
+    },
+  });
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+
+      if (!taskName.trim()) return;
+
+      setIsSubmitting(true);
+      try {
+        // Get first priority label id or empty string if none available
+        const defaultPriority =
+          priorityLabels && priorityLabels.length > 0
+            ? priorityLabels[0].id
+            : "";
+
+        await onCreateTask(columnId, {
+          name: taskName.trim(),
+          description: description.trim(),
+          priorityId: defaultPriority, // Use first available priority from labels
+          completed: false,
+          labelsTags: [],
+          attachments: [],
+          assignedTo: [],
+          subTasks: [],
+          comments: [],
+          // commentsCount removed as it's no longer in schema
+          checklist: checklist,
+          acceptanceCriteria: acceptanceCriteria,
+        });
+
+        setTaskName("");
+        setDescription("");
+        setChecklist([]); // Empty array is fine since it's a reset
+        setAcceptanceCriteria([]); // Empty array is fine since it's a reset
+        setIsSubmitting(false);
+      } catch (error) {
+        console.error("Failed to create task:", error);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [taskName, description, onCreateTask, columnId, onCancel],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    },
+    [onCancel],
+  );
+
+  return (
+    <Box className="p-3 bg-gray-4 rounded-lg border border-gray-6 shadow-sm">
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <TextField.Root
+          value={taskName}
+          onChange={(e) => setTaskName(e.target.value)}
+          placeholder="Enter task title..."
+          autoFocus
+          onKeyDown={handleKeyDown}
+          disabled={isSubmitting || streamingState.isStreaming}
+        />
+
+        {useAI && taskName.trim() && (
+          <Button
+            onClick={() => streamingActions.startStreaming()}
+            disabled={
+              streamingState.isStreaming || !taskName.trim() || isSubmitting
+            }
+            size="1"
+            className="mt-2 mb-2"
+          >
+            {streamingState.isStreaming ? (
+              <>
+                <Icon name="Loader" className="w-4 h-4 mr-2 animate-spin" />
+                Generating...
+              </>
+            ) : (
+              <>
+                <Icon name="Sparkles" className="w-4 h-4 mr-2" />
+                Generate Description
+              </>
+            )}
+          </Button>
+        )}
+
+        <TextArea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder={
+            useAI
+              ? "Generate description with AI or enter manually..."
+              : "Enter task description..."
+          }
+          rows={3}
+          disabled={isSubmitting || streamingState.isStreaming}
+        />
+
+        {/* AI Status Indicator */}
+        {useAI && (
+          <Box className="text-xs">
+            {streamingState.isStreaming && (
+              <Flex align="center" gap="1" className="text-blue-500">
+                <Icon name="Loader" className="animate-spin" />
+                <Text>Generating description...</Text>
+              </Flex>
+            )}
+            {streamingState.error && (
+              <Text className="text-red-500">
+                Failed to generate description: {streamingState.error}
+              </Text>
+            )}
+            {!streamingState.isStreaming &&
+              !streamingState.error &&
+              description &&
+              streamingState.connectionStatus === "completed" && (
+                <Flex align="center" gap="1" className="text-green-600">
+                  <Icon name="Check" />
+                  <Text>AI description generated</Text>
+                </Flex>
+              )}
+          </Box>
+        )}
+
+        <Flex gap="2">
+          <Button
+            type="submit"
+            size="2"
+            disabled={
+              !taskName.trim() || isSubmitting || streamingState.isStreaming
+            }
+            className="flex-1"
+          >
+            {isSubmitting ? "Adding..." : "Add Task"}
+          </Button>
+          <Button
+            type="button"
+            size="2"
+            variant="soft"
+            color="red"
+            onClick={() => {
+              // Cancel streaming if in progress
+              if (streamingState.isStreaming) {
+                streamingActions.stopStreaming();
+              }
+              onCancel();
+            }}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+        </Flex>
+      </form>
+    </Box>
+  );
+});
+
+const variants = cva(
+  "h-full w-80 max-w-full bg-gray-3 flex flex-col flex-shrink-0 snap-center p-0 rounded-b-lg",
+  {
+    variants: {
+      dragging: {
+        default: "border-2 border-transparent",
+        over: "opacity-30",
+        overlay: "bg-gray-12 rounded-t-lg",
+      },
+    },
+  },
+);
+
 export function DndBoardColumn({
   column,
   priorityLabels,
@@ -47,8 +334,45 @@ export function DndBoardColumn({
   onTaskOpen,
   isOverlay,
 }: BoardColumnProps) {
+  const [isEditingColumn, setIsEditingColumn] = useState(false);
+  const [editColumnName, setEditColumnName] = useState(column.name);
+  const [editColumnColor, setEditColumnColor] = useState(column.color);
+  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
+  const colorPickerRef = useRef<HTMLDivElement>(null);
+
+  // Close color picker when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        colorPickerRef.current &&
+        !colorPickerRef.current.contains(event.target as Node)
+      ) {
+        setIsColorPickerOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [colorPickerRef]);
+  const [editColumnDescription, setEditColumnDescription] = useState(
+    column.description || "",
+  );
+  // Modal states
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showErrorModal, setShowErrorModal] = useState(false);
+  const [showValidationModal, setShowValidationModal] = useState(false);
+  const [validationMessage, setValidationMessage] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const [isCreatingTask, setIsCreatingTask] = useState(false);
+
   const sortedTasks = useMemo(() => {
-    return [...column.tasks].sort((a, b) => (a.taskOrder || 0) - (b.taskOrder || 0));
+    return [...column.tasks].sort(
+      (a, b) => (a.taskOrder || 0) - (b.taskOrder || 0),
+    );
   }, [column.tasks]);
 
   const tasksIds = useMemo(() => {
@@ -77,55 +401,280 @@ export function DndBoardColumn({
     transition,
     transform: CSS.Translate.toString(transform),
   };
+  const handleUpdateColumn = useCallback(async () => {
+    if (!editColumnName.trim()) {
+      setValidationMessage("Column name cannot be empty");
+      setShowValidationModal(true);
+      return;
+    }
 
-  const variants = cva(
-    "h-[500px] max-h-[500px] w-[350px] max-w-full bg-primary-foreground flex flex-col flex-shrink-0 snap-center",
-    {
-      variants: {
-        dragging: {
-          default: "border-2 border-transparent",
-          over: "ring-2 opacity-30",
-          overlay: "ring-2 ring-primary",
-        },
-      },
-    },
-  );
+    setIsUpdating(true);
+    try {
+      await onUpdateColumn(column.id, {
+        name: editColumnName.trim(),
+        color: editColumnColor,
+        description: editColumnDescription.trim(),
+      });
+      setIsEditingColumn(false);
+    } catch (error) {
+      console.error("Failed to update column:", error);
+      setValidationMessage("Failed to update column. Please try again.");
+      setShowValidationModal(true);
+    } finally {
+      setIsUpdating(false);
+    }
+  }, [
+    editColumnName,
+    editColumnColor,
+    editColumnDescription,
+    onUpdateColumn,
+    column.id,
+  ]);
 
+  const handleDeleteColumn = useCallback(() => {
+    if (column.tasks.length > 0) {
+      setShowErrorModal(true);
+      return;
+    }
+
+    setShowDeleteModal(true);
+  }, [column.tasks.length]);
+
+  const confirmDeleteColumn = async () => {
+    setIsDeleting(true);
+    try {
+      await onDeleteColumn(column.id);
+      // Modal will close automatically via the preset
+    } catch (error) {
+      console.error("Failed to delete column:", error);
+      setIsDeleting(false);
+    }
+  };
+
+  const handleCancelEdit = useCallback(() => {
+    setIsEditingColumn(false);
+    setEditColumnName(column.name);
+    setEditColumnColor(column.color);
+    setEditColumnDescription(column.description || "");
+  }, [column.name, column.color, column.description]);
+
+  // Calculate column statistics
+  const completedTasks = column.tasks.filter((task) => task.completed).length;
+  const totalTasks = column.tasks.length;
+  const completionPercentage =
+    totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
   return (
-    <Card.Root
-      ref={setNodeRef}
-      style={style}
-      className={variants({
-        dragging: isOverlay ? "overlay" : isDragging ? "over" : undefined,
+    <>
+      {/* Delete Confirmation Modal */}
+      {ModalPresets.deleteColumn({
+        isOpen: showDeleteModal,
+        onOpenChange: setShowDeleteModal,
+        columnName: column.name,
+        onConfirm: confirmDeleteColumn,
+        isLoading: isDeleting,
       })}
-    >
-      <Card.Header className="p-4 font-semibold border-b-2 text-left flex flex-row space-between items-center">
-        <Button
-          variant={"ghost"}
-          {...attributes}
-          {...listeners}
-          className="p-1 text-primary/50 -ml-2 h-auto cursor-grab relative"
-        >
-          <span className="sr-only">{`Move column: ${column.name}`}</span>
-          <Icon name="GripVertical" />
-        </Button>
-        <span className="ml-auto">{column.name}</span>
-      </Card.Header>
 
-      <ScrollArea>
-        <Card.Content className="flex flex-grow flex-col gap-2 p-2">
-          <SortableContext items={tasksIds}>
-            {sortedTasks.map((task) => (
-              <TaskCard 
-                key={task.id} 
-                task={task} 
-                onTaskOpen={onTaskOpen}
-              />
-            ))}
-          </SortableContext>
-        </Card.Content>
-      </ScrollArea>
-    </Card.Root>
+      {/* Error Modal */}
+      {ModalPresets.error({
+        isOpen: showErrorModal,
+        onOpenChange: setShowErrorModal,
+        title: "Cannot Delete Column",
+        description:
+          "This column contains tasks. Please move or delete all tasks from this column before deleting it.",
+      })}
+
+      {/* Validation Error Modal */}
+      {ModalPresets.validation({
+        isOpen: showValidationModal,
+        onOpenChange: setShowValidationModal,
+        message: validationMessage,
+      })}
+
+      <Box
+        ref={setNodeRef}
+        style={style}
+        {...attributes}
+        {...listeners}
+        className={variants({
+          dragging: isOverlay ? "overlay" : isDragging ? "over" : undefined,
+        })}
+      >
+        <Box className="font-semibold text-left flex flex-row space-between items-center">
+          {/* <Button
+            variant={"ghost"}
+            {...attributes}
+            {...listeners}
+            className="p-1 text-primary/50 -ml-2 h-auto cursor-grab relative"
+          >
+            <span className="sr-only">{`Move column: ${column.name}`}</span>
+            <Icon name="GripVertical" />
+          </Button> */}
+          <Box
+            className="flex-shrink-0 p-4 pb-2 cursor-grab active:cursor-grabbing rounded-t-lg w-full"
+            style={{
+              backgroundColor: `${column.color}15`,
+              borderTop: `3px solid ${column.color}`,
+            }}
+          >
+            {isEditingColumn ? (
+              <Flex direction="column" gap="3" className="flex-1">
+                <TextField.Root
+                  value={editColumnName}
+                  onChange={(e) => setEditColumnName(e.target.value)}
+                  placeholder="Column name"
+                  size="2"
+                />
+                <TextArea
+                  value={editColumnDescription}
+                  onChange={(e) => setEditColumnDescription(e.target.value)}
+                  placeholder="Column description (optional)"
+                  rows={2}
+                />
+                <Flex justify={"between"}>
+                  <Flex align="center" gap="2" className="items-start">
+                    <div className="relative" ref={colorPickerRef}>
+                      <Button
+                        variant="solid"
+                        className="color-swatch h-7 w-8 cursor-pointer rounded-sm border border-gray-12"
+                        style={{ backgroundColor: editColumnColor }}
+                        onClick={() => setIsColorPickerOpen(!isColorPickerOpen)}
+                      />
+                      {isColorPickerOpen && (
+                        <div
+                          className="absolute z-50 mt-1"
+                          style={{ minWidth: "240px" }}
+                        >
+                          <ColorPicker
+                            colorType="base"
+                            onColorSelect={(color: ColorSelectType) => {
+                              setEditColumnColor(color.hex);
+                              setIsColorPickerOpen(false);
+                            }}
+                            activeColor={editColumnColor}
+                          />
+                        </div>
+                      )}
+                    </div>
+                    {/* <Text size="1" className="text-gray-500">
+                      Column color
+                    </Text> */}
+                  </Flex>
+                  <Flex gap="2">
+                    <Button
+                      size="1"
+                      className="h-6"
+                      onClick={handleUpdateColumn}
+                      disabled={isUpdating}
+                    >
+                      <Icon name="Check" />
+                      {isUpdating ? "Saving..." : "Save"}
+                    </Button>
+                    <Button
+                      size="1"
+                      variant="soft"
+                      color="red"
+                      className="h-6"
+                      onClick={handleCancelEdit}
+                      disabled={isUpdating}
+                    >
+                      <Icon name="X" />
+                      Cancel
+                    </Button>
+                  </Flex>
+                </Flex>
+              </Flex>
+            ) : (
+              <Flex justify="between" align="center">
+                <Flex align="center" gap="2" className="flex-1 min-w-0">
+                  <Heading
+                    size="5"
+                    as="h3"
+                    className="font-semibold leading-4 truncate"
+                  >
+                    {column.name}
+                  </Heading>
+                  <Flex gap="1" className="flex-shrink-0">
+                    <Text
+                      size="1"
+                      className="text-gray-12 bg-gray-1 px-2 py-1 rounded-1"
+                    >
+                      {totalTasks}
+                    </Text>
+                    {completedTasks > 0 && (
+                      <Text
+                        size="1"
+                        className="text-green-600 bg-green-100 dark:bg-green-900 px-2 py-1 rounded-full"
+                      >
+                        {completionPercentage}%
+                      </Text>
+                    )}
+                  </Flex>
+                </Flex>
+
+                <DropdownMenu.Root>
+                  <DropdownMenu.Trigger>
+                    <IconButton
+                      size="1"
+                      variant="ghost"
+                      className="rounded hover:bg-gray-200 dark:hover:bg-gray-700 flex-shrink-0"
+                    >
+                      <Icon name="EllipsisVertical" />
+                    </IconButton>
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Content>
+                    <DropdownMenu.Item onClick={() => setIsEditingColumn(true)}>
+                      <Icon name="SquarePen" />
+                      Edit Column
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Separator />
+                    <DropdownMenu.Item onClick={handleDeleteColumn} color="red">
+                      <Icon name="Trash2" />
+                      Delete Column
+                    </DropdownMenu.Item>
+                  </DropdownMenu.Content>
+                </DropdownMenu.Root>
+              </Flex>
+            )}
+          </Box>
+        </Box>
+
+          <Box className="flex flex-grow flex-col gap-2 p-4 h-full">
+            <SortableContext items={tasksIds}>
+              {sortedTasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  priorityLabels={priorityLabels}
+                  onUpdateTask={onUpdateTask}
+                  onDeleteTask={onDeleteTask}
+                  onTaskOpen={onTaskOpen}
+                />
+              ))}
+            </SortableContext>
+            {/* Add Task Section - At bottom of content */}
+            <div className="px-3 pb-3 rounded-b-lg">
+              {isCreatingTask ? (
+                <QuickTaskForm
+                  columnId={column.id}
+                  priorityLabels={priorityLabels}
+                  onCreateTask={onCreateTask}
+                  onCancel={() => setIsCreatingTask(false)}
+                />
+              ) : (
+                <Button
+                  variant="soft"
+                  color="blue"
+                  className="grid place-items-center gap-2 w-10 h-10 mx-auto"
+                  onClick={() => setIsCreatingTask(true)}
+                >
+                  <Icon name="Plus" />
+                  <Text className="sr-only">Add a task</Text>
+                </Button>
+              )}
+            </div>
+          </Box>
+      </Box>
+    </>
   );
 }
 
@@ -147,7 +696,7 @@ export function BoardContainer({ children }: { children: React.ReactNode }) {
         dragging: dndContext.active ? "active" : "default",
       })}
     >
-      <div className="flex gap-4 items-center flex-row justify-center">
+      <div className="flex gap-4 items-start flex-row justify-center">
         {children}
       </div>
     </ScrollArea>

--- a/frontend/ui/src/components/kanban-board/dnd-example/BoardColumn.tsx
+++ b/frontend/ui/src/components/kanban-board/dnd-example/BoardColumn.tsx
@@ -192,7 +192,7 @@ const QuickTaskForm = memo(function QuickTaskForm({
         setIsSubmitting(false);
       }
     },
-    [taskName, description, onCreateTask, columnId, onCancel],
+    [taskName, description, onCreateTask, columnId, onCancel, priorityLabels, checklist, acceptanceCriteria],
   );
 
   const handleKeyDown = useCallback(

--- a/frontend/ui/src/components/kanban-board/dnd-example/TaskCard.tsx
+++ b/frontend/ui/src/components/kanban-board/dnd-example/TaskCard.tsx
@@ -22,6 +22,7 @@ import {
 } from "../priority-config";
 import { useAppearanceStore } from "@incmix/store";
 import { useCallback, useState } from "react";
+import { nanoid } from "nanoid";
 
 interface TaskCardProps {
   task: KanbanTask;
@@ -67,7 +68,7 @@ export function TaskCard({
     transition,
     isDragging,
   } = useSortable({
-    id: task?.id || (`task-${Math.random()}` as UniqueIdentifier),
+    id: task?.id || (`task-${nanoid()}` as UniqueIdentifier),
     data: {
       type: "Task",
       task,
@@ -467,7 +468,7 @@ export function TaskCard({
                 )}
                 <IconButton className="flex items-center gap-1 bg-transparent text-gray-700 dark:text-gray-200">
                   <Icon name="MessageSquareText" />
-                  <Text>5</Text>
+                  <Text>{task.comments?.length || 0}</Text>
                 </IconButton>
               </Flex>
               <Flex align={"center"} className="gap-2">

--- a/frontend/ui/src/components/kanban-board/dnd-example/TaskCard.tsx
+++ b/frontend/ui/src/components/kanban-board/dnd-example/TaskCard.tsx
@@ -1,14 +1,38 @@
 import type { UniqueIdentifier } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Button,Badge, Card, Icon } from "@incmix/ui";
+import { Button, Badge, Card, Icon, Heading } from "@incmix/ui";
 import { cva } from "class-variance-authority";
 import { KanbanColumn, KanbanTask } from "../types";
 
+import { isShallowEqual } from "@incmix/utils/objects";
+import { isSafari } from "@utils/browser";
+import { IconButton, DropdownMenu, Box, Flex, Text } from "@base";
+import { toast } from "@incmix/ui";
+
+import { cn } from "@utils";
+import { useKanbanDrawer } from "../hooks/use-kanban-drawer";
+import { ModalPresets } from "../shared/confirmation-modal";
+import { TaskDataSchema } from "@incmix/utils/schema";
+import { RefUrlSummary } from "../shared/ref-url-summary";
+import {
+  getPriorityInfo,
+  getPriorityConfig,
+  PriorityLabel,
+} from "../priority-config";
+import { useAppearanceStore } from "@incmix/store";
+import { useCallback, useState } from "react";
 
 interface TaskCardProps {
   task: KanbanTask;
   isOverlay?: boolean;
+  priorityLabels?: PriorityLabel[]; // Array of priority labels
+  onUpdateTask?: (
+    taskId: string,
+    updates: Partial<TaskDataSchema>,
+  ) => Promise<void>;
+  onDeleteTask?: (taskId: string) => Promise<void>;
+  onTaskOpen?: (taskId: string) => void;
 }
 
 export type TaskType = "Task";
@@ -18,8 +42,22 @@ export interface TaskDragData {
   task: KanbanTask;
 }
 
-export function TaskCard({ task, isOverlay }: TaskCardProps) {
-
+const variants = cva("", {
+  variants: {
+    dragging: {
+      over: "ring-2 opacity-30 rounded-lg",
+      overlay: "bg-orange-500 text-white rounded-lg",
+    },
+  },
+});
+export function TaskCard({
+  task,
+  isOverlay,
+  priorityLabels,
+  onUpdateTask,
+  onDeleteTask,
+  onTaskOpen,
+}: TaskCardProps) {
   // console.log("task", task);
   const {
     setNodeRef,
@@ -29,7 +67,7 @@ export function TaskCard({ task, isOverlay }: TaskCardProps) {
     transition,
     isDragging,
   } = useSortable({
-    id: task?.id || `task-${Math.random()}` as UniqueIdentifier,
+    id: task?.id || (`task-${Math.random()}` as UniqueIdentifier),
     data: {
       type: "Task",
       task,
@@ -44,40 +82,425 @@ export function TaskCard({ task, isOverlay }: TaskCardProps) {
     transform: CSS.Translate.toString(transform),
   };
 
-  const variants = cva("", {
-    variants: {
-      dragging: {
-        over: "ring-2 opacity-30",
-        overlay: "ring-2 bg-gray-12 text-gray-1",
-      },
+  const { appearance, toggleAppearance } = useAppearanceStore();
+  const { handleDrawerOpen } = useKanbanDrawer();
+
+  const handleTaskClick = useCallback(
+    (e: React.MouseEvent) => {
+      // Don't open task if clicking on dropdown or other interactive elements
+      if (
+        e.target instanceof Element &&
+        (e.target.closest("[data-no-drawer]") ||
+          e.target.closest('[role="menuitem"]'))
+      ) {
+        return;
+      }
+
+      // Ensure task.id exists before using it
+      if (!task.id) return;
+
+      // Simple direct approach - just open the drawer
+      console.log("Opening task drawer for:", task.id);
+      handleDrawerOpen(task.id);
+
+      // If onTaskOpen exists, call it after handleDrawerOpen
+      if (onTaskOpen && task.id) {
+        onTaskOpen(task.id);
+      }
     },
-  });
+    [task.id, handleDrawerOpen, onTaskOpen],
+  );
+
+  const handleToggleCompleted = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      if (!onUpdateTask || !task.id) return;
+
+      // setIsUpdating(true)
+      onUpdateTask(task.id, { completed: !task.completed })
+        .then(() => {
+          // setIsUpdating(false)
+        })
+        .catch((err) => {
+          // setIsUpdating(false)
+          console.error("Error updating task completion status:", err);
+          toast.error(
+            "Could not update task completion status. Please try again.",
+            {
+              duration: 5000,
+            },
+          );
+        });
+    },
+    [task.completed, task.id, onUpdateTask],
+  );
+
+  // Handle task actions
+  const handleEdit = useCallback(() => {
+    if (onTaskOpen && task.id) {
+      onTaskOpen(task.id);
+    } else if (task.id) {
+      handleDrawerOpen(task.id);
+    }
+  }, [task.id, handleDrawerOpen, onTaskOpen]);
+
+  // Modal state for task deletion
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = useCallback(() => {
+    setShowDeleteConfirmation(true);
+  }, [task.id]);
+
+  // Confirm task deletion handler
+  const confirmDelete = useCallback(() => {
+    if (!onDeleteTask || !task.id) return;
+
+    setIsDeleting(true);
+    onDeleteTask(task.id)
+      .then(() => {
+        setIsDeleting(false);
+        setShowDeleteConfirmation(false);
+      })
+      .catch((err) => {
+        setIsDeleting(false);
+        console.error("Error deleting task:", err);
+        toast.error("Could not delete task. Please try again.", {
+          duration: 5000,
+        });
+      });
+  }, [task.id, onDeleteTask]);
+
+  // Using the shared priority configuration from priority-config.ts - will be updated with dynamic labels
+  // Note: The TaskCard should receive priorityLabels from its parent to avoid hardcoded values
+
+  const formatDate = useCallback((date?: Date) => {
+    if (!date) return { text: "", className: "" };
+
+    const now = new Date();
+    const diffTime = date.getTime() - now.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+    if (diffDays < 0) {
+      return {
+        text: `${Math.abs(diffDays)} day${Math.abs(diffDays) > 1 ? "s" : ""} overdue`,
+        className: "text-red-600 bg-red-50 border-red-200",
+      };
+    } else if (diffDays === 0) {
+      return {
+        text: "Due today",
+        className: "text-orange-600 bg-orange-50 border-orange-200",
+      };
+    } else if (diffDays === 1) {
+      return {
+        text: "Due tomorrow",
+        className: "text-yellow-600 bg-yellow-50 border-yellow-200",
+      };
+    } else if (diffDays <= 7) {
+      return {
+        text: `Due in ${diffDays} days`,
+        className: "text-blue-600 bg-blue-50 border-blue-200",
+      };
+    }
+
+    return {
+      text: date.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      }),
+      className: "text-gray-600 bg-gray-50 border-gray-200",
+    };
+  }, []);
+
+  const completedSubTasks =
+    task.subTasks?.filter((st) => st.completed).length || 0;
+  const totalSubTasks = task.subTasks?.length || 0;
+  const progressPercentage =
+    totalSubTasks > 0 ? (completedSubTasks / totalSubTasks) * 100 : 0;
+
+  // Use new getPriorityConfig function which works with priorityLabels
+  const priorityInfo = getPriorityConfig(task.priorityId, priorityLabels);
+  const PriorityIcon = priorityInfo.icon;
+  const dueDateInfo = formatDate(
+    typeof task.startDate === "number" ? new Date(task.startDate) : undefined,
+  );
 
   return (
-    <Card.Root
-      ref={setNodeRef}
-      style={style}
-      className={variants({
-        dragging: isOverlay ? "overlay" : isDragging ? "over" : undefined,
+    <>
+      {ModalPresets.deleteTask({
+        isOpen: showDeleteConfirmation,
+        onOpenChange: setShowDeleteConfirmation,
+        onConfirm: confirmDelete,
+        taskName: task.name,
+        isLoading: isDeleting,
       })}
-    >
-      <Card.Header className="px-3 py-3 space-between flex flex-row border-b-2 border-secondary relative">
-        <Button
-          variant={"ghost"}
-          {...attributes}
-          {...listeners}
-          className="p-1 text-secondary-foreground/50 -ml-2 h-auto cursor-grab"
+
+      <Box
+        ref={setNodeRef}
+        style={style}
+        {...attributes}
+        {...listeners}
+        className={cn(
+          "relative cursor-pointer p-0 space-y-3 group",
+          task.completed && "opacity-75",
+          variants({
+            dragging: isOverlay ? "overlay" : isDragging ? "over" : undefined,
+          })
+        )}
+      >
+        <Box
+          onClick={handleTaskClick}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === "Space") {
+              e.preventDefault();
+              handleTaskClick(e as unknown as React.MouseEvent);
+            }
+          }}
+          className={cn("flex flex-shrink-0 flex-col gap-1")}
         >
-          <span className="sr-only">Move task</span>
-          <Icon name="GripVertical" />
-        </Button>
-        <Badge variant={"outline"} className="ml-auto font-semibold">
-          Task
-        </Badge>
-      </Card.Header>
-      <Card.Content className="px-3 pt-3 pb-6 text-left whitespace-pre-wrap">
-        {task.name}
-      </Card.Content>
-    </Card.Root>
+          <Box
+            className={cn(
+              "relative p-3 space-y-3 bg-gray-1 rounded-lg active:cursor-grabbing cursor-grab border border-gray-5 group",
+              task.completed && "opacity-75",
+            )}
+          >
+            {/* Task Header with Priority and Actions */}
+            <Flex justify="between" align="start" className="gap-2 -mt-1">
+              <Flex align="center" gap="2" className="flex-1 min-w-0">
+                {/* Priority indicator */}
+                {task.priorityId && (
+                  <Badge
+                    size="1"
+                    color="gray"
+                    variant="soft"
+                    className={`px-2 py-0.5 ${getPriorityInfo(task.priorityId).color}`}
+                  >
+                    {getPriorityInfo(task.priorityId).label}
+                  </Badge>
+                )}
+
+                {/* Completion status */}
+                {task.completed && (
+                  <Badge
+                    color="green"
+                    size="1"
+                    variant="solid"
+                    className="flex-shrink-0"
+                  >
+                    Done
+                  </Badge>
+                )}
+              </Flex>
+              <Flex align="center" gap="2">
+                {/* Due Date */}
+                {dueDateInfo.text && (
+                  <Flex align="center" gap="1">
+                    <Icon name="CalendarDays" />
+                    <Text
+                      size="2"
+                      className={cn(
+                        "px-0.5 py-0.5 rounded-md",
+                        // dueDateInfo.className,
+                      )}
+                    >
+                      {dueDateInfo.text}
+                    </Text>
+                  </Flex>
+                )}
+                {/* Actions Menu */}
+                <DropdownMenu.Root>
+                  <DropdownMenu.Trigger>
+                    <IconButton
+                      size="1"
+                      variant="ghost"
+                      onClick={(e) => e.stopPropagation()}
+                      className=""
+                    >
+                      <Icon name="EllipsisVertical" />
+                    </IconButton>
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Content>
+                    <DropdownMenu.Item onClick={handleEdit}>
+                      <Icon name="SquarePen" />
+                      Edit Task
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                      onClick={(e) =>
+                        handleToggleCompleted(
+                          e as unknown as React.MouseEvent<HTMLButtonElement>,
+                        )
+                      }
+                    >
+                      <Icon name="SquareCheck" />
+                      {task.completed ? "Mark Incomplete" : "Mark Complete"}
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Separator />
+                    <DropdownMenu.Item onClick={handleDelete} color="red">
+                      <Icon name="Trash2" />
+                      Delete Task
+                    </DropdownMenu.Item>
+                  </DropdownMenu.Content>
+                </DropdownMenu.Root>
+              </Flex>
+            </Flex>
+            {task.assignedTo && (
+              <Flex align={"center"} gap={"1"}>
+                {task.assignedTo.map((assignee) => {
+                  const colors = [
+                    "bg-green-400",
+                    "bg-yellow-400",
+                    "bg-orange-400",
+                    "bg-cyan-400",
+                    "bg-red-400",
+                  ];
+                  // Create a deterministic color based on the assignee's name
+                  const nameSum = assignee.name
+                    .split("")
+                    .reduce((sum, char) => sum + char.charCodeAt(0), 0);
+                  const colorIndex = nameSum % colors.length;
+                  const stableColor = colors[colorIndex];
+                  return (
+                    <Text
+                      key={assignee.name}
+                      className={`flex h-1 w-6 items-center gap-1 rounded-full ${stableColor}`}
+                    />
+                  );
+                })}
+              </Flex>
+            )}
+            {/* Task Title */}
+            <Heading
+              as="h4"
+              size="3"
+              className={cn(
+                "font-medium line-clamp-2 transition-colors leading-tight",
+                task.completed && "line-through text-gray-11",
+              )}
+            >
+              {task.name}
+            </Heading>
+
+            {/* Task Description */}
+            {task.description && (
+              <Text className="text-gray-600 dark:text-gray-400 text-sm line-clamp-2 leading-relaxed">
+                {task.description}
+              </Text>
+            )}
+
+            {/* Labels */}
+            {task.labelsTags && task.labelsTags.length > 0 && (
+              <Flex gap="1" wrap="wrap">
+                {task.labelsTags.slice(0, 3).map((label, index) => (
+                  <Badge
+                    key={`${label.value}-${index}`}
+                    size="1"
+                    variant="soft"
+                    style={{
+                      backgroundColor: label.color + "20",
+                      color: label.color,
+                    }}
+                    className="text-xs border"
+                  >
+                    {label.label}
+                  </Badge>
+                ))}
+                {task.labelsTags.length > 3 && (
+                  <Badge
+                    size="1"
+                    variant="soft"
+                    color="gray"
+                    className="text-xs"
+                  >
+                    +{task.labelsTags.length - 3} more
+                  </Badge>
+                )}
+              </Flex>
+            )}
+
+            {/* Subtasks Progress */}
+            {totalSubTasks > 0 && (
+              <Box className="space-y-2">
+                <Flex align="center" justify="between">
+                  <Flex align="center" gap="1">
+                    <Icon name="SquareCheck" className="text-gray-11" />
+                    <Text size="1" className="text-gray-11 font-medium">
+                      {completedSubTasks}/{totalSubTasks} subtasks
+                    </Text>
+                  </Flex>
+                  <Text size="1" className="text-gray-11 font-medium">
+                    {Math.round(progressPercentage)}%
+                  </Text>
+                </Flex>
+                <div className="w-full bg-gray-6 rounded-full h-1.5">
+                  <div
+                    className={cn(
+                      "h-1.5 rounded-full transition-all duration-300",
+                      progressPercentage === 100
+                        ? "bg-green-500"
+                        : "bg-blue-500",
+                    )}
+                    style={{ width: `${progressPercentage}%` }}
+                  />
+                </div>
+              </Box>
+            )}
+
+            {/* Footer with meta information */}
+
+            <Flex
+              align={"center"}
+              justify={"between"}
+              className="gap-2 py-1 w-full"
+            >
+              <Flex align={"center"} gap="4">
+                {/* Reference URLs */}
+                <RefUrlSummary
+                  refUrls={task.refUrls}
+                  className="text-gray-12"
+                />
+
+                {task.attachments && (
+                  <IconButton className="flex items-center gap-1 bg-transparent text-gray-700 dark:text-gray-200">
+                    <Icon name="Paperclip" />
+                    <Text>{task.attachments.length}</Text>
+                  </IconButton>
+                )}
+                <IconButton className="flex items-center gap-1 bg-transparent text-gray-700 dark:text-gray-200">
+                  <Icon name="MessageSquareText" />
+                  <Text>5</Text>
+                </IconButton>
+              </Flex>
+              <Flex align={"center"} className="gap-2">
+                {task.assignedTo && task.assignedTo.length > 0 && (
+                  <Flex align="center" className="-space-x-2">
+                    {task.assignedTo.slice(0, 3).map((member, index) => (
+                      <div
+                        key={member.id}
+                        className="h-8 w-8 rounded-full bg-gray-5 flex items-center justify-center border border-gray-7 text-gray-11"
+                        style={{ zIndex: 3 - index }}
+                        title={member.name}
+                      >
+                        {member.name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")
+                          .toUpperCase()
+                          .slice(0, 2)}
+                      </div>
+                    ))}
+                    {task.assignedTo.length > 3 && (
+                      <div className="h-8 w-8 rounded-full bg-gray-3 flex items-center justify-center border border-gray-7 text-xs font-medium text-gray-11">
+                        +{task.assignedTo.length - 3}
+                      </div>
+                    )}
+                  </Flex>
+                )}
+              </Flex>
+            </Flex>
+            {/* Assigned users */}
+          </Box>
+        </Box>
+      </Box>
+    </>
   );
 }


### PR DESCRIPTION

You can compare the Atlassian Kanban Board and the DnD Kit Kanban Board.

Go to:
`frontend/ui/src/components/kanban-board/board/index.tsx`

I've commented out the Atlassian Board implementation.
To test it instead of the current one, simply comment out <DndKanbanBoard /> and uncomment the Atlassian board.

<img width="1631" height="925" alt="image" src="https://github.com/user-attachments/assets/695fb7bb-9c76-48c9-9901-5dbd29d248ed" />
<img width="1598" height="918" alt="image" src="https://github.com/user-attachments/assets/018778f8-8280-42c2-9373-cba7a207932a" />
